### PR TITLE
hcc - support for multiple devices

### DIFF
--- a/HCCStream.cpp
+++ b/HCCStream.cpp
@@ -45,10 +45,6 @@ void listDevices(void)
   }
 }
 
-
-#define SCC_VERIFY (1)
-
-
 template <class T>
 HCCStream<T>::HCCStream(const unsigned int ARRAY_SIZE, const int device_index):
   array_size(ARRAY_SIZE),
@@ -88,45 +84,6 @@ void HCCStream<T>::write_arrays(const std::vector<T>& a, const std::vector<T>& b
   hc::copy(a.cbegin(),a.cend(),d_a);
   hc::copy(b.cbegin(),b.cend(),d_b);
   hc::copy(c.cbegin(),c.cend(),d_c);
-
-
-
-#if (SCC_VERIFY!=0) 
-{
-   hc::array_view<T> av_d_a(d_a);
-   int errors = 0;
-   int avi = 0;
-   for (auto i = a.begin(); i != a.end(); i++,avi++) {
-     if (av_d_a[avi] != *i)
-       errors++;
-   }
-   printf("%d errors in d_a\n",errors);
-}
-
-{
-   hc::array_view<T> av_d_b(d_b);
-   int errors = 0;
-   int avi = 0;
-   for (auto i = b.begin(); i != b.end(); i++,avi++) {
-     if (av_d_b[avi] != *i)
-       errors++;
-   }
-   printf("%d errors in d_b\n",errors);
-}
-
-{
-   hc::array_view<T> av_d_c(d_c);
-   int errors = 0;
-   int avi = 0;
-   for (auto i = c.begin(); i != c.end(); i++,avi++) {
-     if (av_d_c[avi] != *i)
-       errors++;
-   }
-   printf("%d errors in d_c\n",errors);
-}
-#endif
-
-
 }
 
 template <class T>
@@ -141,13 +98,8 @@ void HCCStream<T>::read_arrays(std::vector<T>& a, std::vector<T>& b, std::vector
 template <class T>
 void HCCStream<T>::copy()
 {
-
-  std::cout << "In " << __FUNCTION__ << std::endl;
-
-#if 1
   hc::array<T> &d_a = this->d_a;
   hc::array<T> &d_c = this->d_c;
-#endif
 
   try{
   // launch a GPU kernel to compute the saxpy in parallel 
@@ -158,24 +110,6 @@ void HCCStream<T>::copy()
 								 d_c[i] = d_a[i];
 								});
     future_kernel.wait();
-
-
-#if (SCC_VERIFY!=0) 
-{
-   hc::array_view<T> av_d_c(d_c);
-   hc::array_view<T> av_d_a(d_a);
-   int errors = 0;
-   for (int i = 0; i < array_size; i++) {
-     if (av_d_c[i]!=av_d_a[i]) {
-       errors++;
-     }
-   }
-   printf("%s %d errors\n",__FUNCTION__,errors);
-}
-#endif
-
-
-
   }
   catch(std::exception& e){
     std::cout << e.what() << std::endl;
@@ -186,8 +120,6 @@ void HCCStream<T>::copy()
 template <class T>
 void HCCStream<T>::mul()
 {
-  std::cout << "In " << __FUNCTION__ << std::endl;
-
   hc::array<T> &d_b = this->d_b;
   hc::array<T> &d_c = this->d_c;
 
@@ -210,9 +142,6 @@ void HCCStream<T>::mul()
 template <class T>
 void HCCStream<T>::add()
 {
-
-  std::cout << "In " << __FUNCTION__ << std::endl;
-
   hc::array<T> &d_a = this->d_a;
   hc::array<T> &d_b = this->d_b;
   hc::array<T> &d_c = this->d_c;
@@ -235,9 +164,6 @@ void HCCStream<T>::add()
 template <class T>
 void HCCStream<T>::triad()
 {
-
-  std::cout << "In " << __FUNCTION__ << std::endl;
-
   hc::array<T> &d_a = this->d_a;
   hc::array<T> &d_b = this->d_b;
   hc::array<T> &d_c = this->d_c;

--- a/HCCStream.cpp
+++ b/HCCStream.cpp
@@ -46,6 +46,8 @@ void listDevices(void)
 }
 
 
+#define SCC_VERIFY (1)
+
 
 template <class T>
 HCCStream<T>::HCCStream(const unsigned int ARRAY_SIZE, const int device_index):
@@ -86,6 +88,45 @@ void HCCStream<T>::write_arrays(const std::vector<T>& a, const std::vector<T>& b
   hc::copy(a.cbegin(),a.cend(),d_a);
   hc::copy(b.cbegin(),b.cend(),d_b);
   hc::copy(c.cbegin(),c.cend(),d_c);
+
+
+
+#if (SCC_VERIFY!=0) 
+{
+   hc::array_view<T> av_d_a(d_a);
+   int errors = 0;
+   int avi = 0;
+   for (auto i = a.begin(); i != a.end(); i++,avi++) {
+     if (av_d_a[avi] != *i)
+       errors++;
+   }
+   printf("%d errors in d_a\n",errors);
+}
+
+{
+   hc::array_view<T> av_d_b(d_b);
+   int errors = 0;
+   int avi = 0;
+   for (auto i = b.begin(); i != b.end(); i++,avi++) {
+     if (av_d_b[avi] != *i)
+       errors++;
+   }
+   printf("%d errors in d_b\n",errors);
+}
+
+{
+   hc::array_view<T> av_d_c(d_c);
+   int errors = 0;
+   int avi = 0;
+   for (auto i = c.begin(); i != c.end(); i++,avi++) {
+     if (av_d_c[avi] != *i)
+       errors++;
+   }
+   printf("%d errors in d_c\n",errors);
+}
+#endif
+
+
 }
 
 template <class T>
@@ -97,18 +138,44 @@ void HCCStream<T>::read_arrays(std::vector<T>& a, std::vector<T>& b, std::vector
   hc::copy(d_c,c.begin());
 }
 
-
 template <class T>
 void HCCStream<T>::copy()
 {
+
+  std::cout << "In " << __FUNCTION__ << std::endl;
+
+#if 1
+  hc::array<T> &d_a = this->d_a;
+  hc::array<T> &d_c = this->d_c;
+#endif
+
   try{
   // launch a GPU kernel to compute the saxpy in parallel 
     hc::completion_future future_kernel = hc::parallel_for_each(accelerator.get_default_view()
                 , hc::extent<1>(array_size)
 								, [&](hc::index<1> i) __attribute((hc)) {
-								  d_c[i] = d_a[i];
+
+								 d_c[i] = d_a[i];
 								});
     future_kernel.wait();
+
+
+#if (SCC_VERIFY!=0) 
+{
+   hc::array_view<T> av_d_c(d_c);
+   hc::array_view<T> av_d_a(d_a);
+   int errors = 0;
+   for (int i = 0; i < array_size; i++) {
+     if (av_d_c[i]!=av_d_a[i]) {
+       errors++;
+     }
+   }
+   printf("%s %d errors\n",__FUNCTION__,errors);
+}
+#endif
+
+
+
   }
   catch(std::exception& e){
     std::cout << e.what() << std::endl;
@@ -119,6 +186,11 @@ void HCCStream<T>::copy()
 template <class T>
 void HCCStream<T>::mul()
 {
+  std::cout << "In " << __FUNCTION__ << std::endl;
+
+  hc::array<T> &d_b = this->d_b;
+  hc::array<T> &d_c = this->d_c;
+
   const T scalar = 0.3;
   try{
   // launch a GPU kernel to compute the saxpy in parallel 
@@ -138,6 +210,13 @@ void HCCStream<T>::mul()
 template <class T>
 void HCCStream<T>::add()
 {
+
+  std::cout << "In " << __FUNCTION__ << std::endl;
+
+  hc::array<T> &d_a = this->d_a;
+  hc::array<T> &d_b = this->d_b;
+  hc::array<T> &d_c = this->d_c;
+
   try{
     // launch a GPU kernel to compute the saxpy in parallel 
     hc::completion_future future_kernel = hc::parallel_for_each(accelerator.get_default_view()
@@ -156,6 +235,13 @@ void HCCStream<T>::add()
 template <class T>
 void HCCStream<T>::triad()
 {
+
+  std::cout << "In " << __FUNCTION__ << std::endl;
+
+  hc::array<T> &d_a = this->d_a;
+  hc::array<T> &d_b = this->d_b;
+  hc::array<T> &d_c = this->d_c;
+
   const T scalar = 0.3;
   try{
     // launch a GPU kernel to compute the saxpy in parallel 

--- a/HCCStream.h
+++ b/HCCStream.h
@@ -23,6 +23,9 @@ protected:
   // Size of arrays
   unsigned int array_size;
 
+  // Selected device
+  hc::accelerator accelerator;
+
   // Device side pointers to arrays
   hc::array<T,1> d_a;
   hc::array<T,1> d_b;

--- a/main.cpp
+++ b/main.cpp
@@ -39,13 +39,7 @@
 #endif
 
 // Default size of 2^25
-//unsigned int ARRAY_SIZE = 33554432;
-
-//unsigned int ARRAY_SIZE = 1024 * 1024;
-
-unsigned int ARRAY_SIZE = 1024;
-
-
+unsigned int ARRAY_SIZE = 33554432;
 
 unsigned int num_times = 100;
 unsigned int deviceIndex = 0;
@@ -138,14 +132,9 @@ void run()
   stream = new OMP45Stream<T>(ARRAY_SIZE, a.data(), b.data(), c.data(), deviceIndex);
 
 #elif defined(HCC)
-
-  HCCStream<T>* gpu_buffer =  (HCCStream<T>*)  hc::allocate_coarsed_grain_system_memory(sizeof(HCCStream<T>));
-  stream = new(gpu_buffer) HCCStream<T>(ARRAY_SIZE, deviceIndex);
-  
-
   // Use the "reference" OpenMP 3 implementation
-  //stream = new HCCStream<T>(ARRAY_SIZE, deviceIndex);
-  
+  stream = new HCCStream<T>(ARRAY_SIZE, deviceIndex);
+
 #endif
 
   stream->write_arrays(a, b, c);
@@ -182,7 +171,6 @@ void run()
     stream->triad();
     t2 = std::chrono::high_resolution_clock::now();
     timings[3].push_back(std::chrono::duration_cast<std::chrono::duration<double> >(t2 - t1).count());
-
 
   }
 
@@ -226,13 +214,7 @@ void run()
       << std::endl;
 
   }
-
-#ifdef HCC
-  stream->~Stream();
-  hc::free_system_memory((void*)gpu_buffer);
-#else
   delete stream;
-#endif
 }
 
 template <typename T>


### PR DESCRIPTION
Here are a couple changes to this benchmark to support device selection on a multi-gpu system.  It's mostly changing array allocations to allocate memory from the selected device and also to launch kernels to the selected device.
